### PR TITLE
replace confirmation link with OTP for sign up

### DIFF
--- a/crowdship-app/app.json
+++ b/crowdship-app/app.json
@@ -1,8 +1,8 @@
 {
   "expo": {
-    "name": "crowdship-app",
-    "slug": "crowdship-app",
-    "scheme": "crowdshipapp",
+    "name": "crowdship",
+    "slug": "crowdship",
+    "scheme": "com.crowdship",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -14,7 +14,7 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.anonymous.crowdship-app"
+      "bundleIdentifier": "com.anonymous.crowdship"
     },
     "android": {
       "adaptiveIcon": {


### PR DESCRIPTION
Replaced the confirmation link from the signup email with an OTP. Some email services automatically pre-open the link to check if it's safe, so that could potentially expire the token, but it won't happen now since it's OTP based