### PR TITLE
Only render start delivery for in progress listings

### DIFF
--- a/crowdship-app/components/DefaultDeliveryModal.tsx
+++ b/crowdship-app/components/DefaultDeliveryModal.tsx
@@ -130,14 +130,14 @@ const DefaultDeliveryModal: React.FC<DefaultDeliveryModalProps> = ({
             </View>
           </View>
 
-          {/* Chat Button */}
-
-          <TouchableOpacity
-            style={buttonStyles.primaryButton}
-            onPress={handleStartDelivery}
-          >
-            <Text style={buttonStyles.buttonText}>Start Delivery</Text>
-          </TouchableOpacity>
+          {selectedListing.status === "CLAIMED" && (
+            <TouchableOpacity
+              style={buttonStyles.primaryButton}
+              onPress={handleStartDelivery}
+            >
+              <Text style={buttonStyles.buttonText}>Start Delivery</Text>
+            </TouchableOpacity>
+          )}
 
           {message && (
             <Text style={[fontStyles.greenText, { marginTop: 10 }]}>


### PR DESCRIPTION
You should only see the start delivery button for in progress deliveries.